### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
 
     name = name, version = version,
     long_description=long_description,
-    description = long_description.strip().split('\n')[0],
+    description = long_description.strip().split('\n')[3],
     packages = [name.split('.')[0], name],
     namespace_packages = [name.split('.')[0]],
     package_dir = {'': 'src'},


### PR DESCRIPTION
`long_description.strip().split('\n')[0]` picks up the wrong line which is the travis badge url `long_description.strip().split('\n')[3]` picks up the right line.
